### PR TITLE
Called the quickCreate function in the constructor

### DIFF
--- a/src/BelongsToWithCreate.php
+++ b/src/BelongsToWithCreate.php
@@ -14,6 +14,9 @@ class BelongsToWithCreate extends BelongsTo
      */
     public $component = 'BelongsToWithCreate';
 
+    /**
+     * @inheritdoc
+     */
     public function __construct($name, $attribute = null, $resource = null) {
         parent::__construct($name, $attribute, $resource);
 

--- a/src/BelongsToWithCreate.php
+++ b/src/BelongsToWithCreate.php
@@ -14,7 +14,13 @@ class BelongsToWithCreate extends BelongsTo
      */
     public $component = 'BelongsToWithCreate';
 
-    public function quickCreate($fillValues = [])
+    public function __construct($name, $attribute = null, $resource = null) {
+        parent::__construct($name, $attribute, $resource);
+
+        $this->quickCreate();
+    }
+
+    private function quickCreate($fillValues = [])
     {
         $this->withMeta(['quickCreate' => true, 'fillValues' => $fillValues]);
 


### PR DESCRIPTION
I've made the quickCreate function private and added it to the constructor, this prevents the need to call it yourself over and over.